### PR TITLE
Enable CI testing on 3.10

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, '3.10']
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Include python 3.10 in the testing matrix (and 3.11 will be released soon as well)

This PR is motivated by the fact that I've seen pytest failing some tests for 3.10 on win and macos. However, it happened on a branch with other commits so it might be a false positive. Merging this minimal change set to the main branch could help to clarify that ;)